### PR TITLE
Properly persist event images, improve cropping interface, fix some translations

### DIFF
--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -51,11 +51,14 @@
   %hr
   .form-group
     = form.text_area :description, class: 'form-control', style: "height: 10em;", floating: true, help: t('event.form.description_uses_markdown_html', link: link_to(t('event.form.description_uses_markdown_name'), 'https://www.markdownguide.org/basic-syntax/'))
+  %hr
   .form-group.mb-2
-    %h3= t('poll.plural')
+    %h3= Poll.model_name.human(count: 2)
     #polls
       = form.fields_for(:polls, layout: :inline) do |f|
         = render partial: "polls/form", locals: {f: f}
     = link_to_add_fields t('poll.add_prompt'), form, :polls, {partial: 'polls/form', target: "#polls", locals: { poll: form.object.polls.build }, layout: :inline, child_index: 'added_poll'}, class: 'btn btn-success', id: "add-poll"
+  %hr
   .actions
     = form.primary
+    = link_to t('back'), events_path, class: 'ms-2 btn btn-light'

--- a/app/views/events/_form.html.haml
+++ b/app/views/events/_form.html.haml
@@ -1,22 +1,29 @@
-.card.mx-md-5
-  .card-header.text-center.text-bg-secondary= t('event.form.preview_label')
-  .hero
-    .hero-image
-      %small.form-text#crop-instruction= t('event.form.header_photo_crop_prompt')
-      %img#photo-preview{src: event.photo.attached? ? url_for(event.photo) : image_path('default_event_image.jpg'), data: {initial_y_offset: event.photo_crop_y_offset}}
-    .mx-2
-      .hero-title
-        %h1.title.display-4#title-preview{data: {default: t('event.title_placeholder')}}
-        %em.text-muted.mb-2
-          = t('event.show.hosted_by_you')
-  .mx-1.alert.alert-danger.text-center.emojified-warning#requires-testing
-    %strong= t('event.show.requires_testing')
-  .card-footer.text-center.text-bg-secondary= t('event.form.preview_label')
+- # svg config for info circle
+%svg.d-none{xmlns: "http://www.w3.org/2000/svg"}
+  %symbol#info-fill{viewBox: "0 0 16 16", fill: 'currentColor'}
+    %path{d: "M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16zm.93-9.412-1 4.705c-.07.34.029.533.304.533.194 0 .487-.07.686-.246l-.088.416c-.287.346-.92.598-1.465.598-.703 0-1.002-.422-.808-1.319l.738-3.468c.064-.293.006-.399-.287-.47l-.451-.081.082-.381 2.29-.287zM8 5.5a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"}
+
+.accordion.p-1.mx-md-5
+  .accordion-item
+    .accordion-header.d-grid
+      %button.accordion-button.collapsed.gap-2.btn.text-bg-secondary{type: 'button', data: {bs: {toggle: 'collapse', target: '#preview'}}, aria: {expanded: 'false', controls: 'preview'}}= t('event.form.preview_label')
+    #preview.accordion-collapse.collapse
+      .alert.alert-info.m-3.d-inline-flex.flex-shrink-0.align-items-center
+        %svg.bi.flex-shrink-0.me-2{role: "img", width: '1em', height: '1em', aria: {label: "Info:"}}
+          %use{'xlink:href' => "#info-fill"}
+        %div= t('event.form.header_photo_crop_prompt')
+      .hero.border-top
+        .hero-image
+          %img#photo-preview{src: event.photo.attached? ? rails_storage_redirect_path(event.photo) : image_path('default_event_image.jpg'), data: {initial_y_offset: event.photo_crop_y_offset}}
+        .mx-2
+          .hero-title
+            %h1.title.display-4#title-preview{data: {default: t('event.title_placeholder')}}
+            %em.text-muted.mb-2
+              = t('event.show.hosted_by_you')
+      .mx-1.alert.alert-danger.text-center.emojified-warning#requires-testing
+        %strong= t('event.show.requires_testing')
 %hr
 = bootstrap_form_for(event, url: event.persisted? ? event_path(event) : events_path) do |form|
-  - if event.errors.any?
-    #error_explanation
-      %h2= t('event.form.errors_msg')
   = form.text_field :title, floating: true
   = form.form_group(class: 'row') do
     .col-md-6
@@ -36,6 +43,8 @@
         = render "shared/info_tooltip", message: t('event.form.testing_help')
   .form-group
     = form.hidden_field :photo_crop_y_offset
+    - if event.photo.attached?
+      = form.hidden_field :photo, value: form.object.photo.signed_id
     = form.file_field :photo, direct_upload: true, help: t('event.form.header_photo_help')
     %strong.form-text#crop-prompt= t('event.form.header_photo_crop_prompt')
   = render partial: "addresses/form", locals: { parent_form: form, address: event.address }
@@ -43,10 +52,10 @@
   .form-group
     = form.text_area :description, class: 'form-control', style: "height: 10em;", floating: true, help: t('event.form.description_uses_markdown_html', link: link_to(t('event.form.description_uses_markdown_name'), 'https://www.markdownguide.org/basic-syntax/'))
   .form-group.mb-2
-    %h3 Polls
+    %h3= t('poll.plural')
     #polls
       = form.fields_for(:polls, layout: :inline) do |f|
         = render partial: "polls/form", locals: {f: f}
-    = link_to_add_fields t('event.form.add_poll'), form, :polls, {partial: 'polls/form', target: "#polls", locals: { poll: form.object.polls.build }, layout: :inline, child_index: 'added_poll'}, class: 'btn btn-success', id: "add-poll"
+    = link_to_add_fields t('poll.add_prompt'), form, :polls, {partial: 'polls/form', target: "#polls", locals: { poll: form.object.polls.build }, layout: :inline, child_index: 'added_poll'}, class: 'btn btn-success', id: "add-poll"
   .actions
     = form.primary

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,3 +1,2 @@
 - title t('event.form.title.edit', title: @event.title)
 = render 'form', event: @event
-= link_to t('back'), events_path

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,4 +1,3 @@
 - title t('event.form.title.edit', title: @event.title)
-%h1.title= t('event.form.header.edit', title: @event.title)
 = render 'form', event: @event
 = link_to t('back'), events_path

--- a/app/views/events/new.html.haml
+++ b/app/views/events/new.html.haml
@@ -1,4 +1,2 @@
 - title t('event.form.title.new')
-%h1.title= t('event.form.header.new')
 = render 'form', event: @event
-= link_to t('back'), events_path, class: 'button is-white'

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -4,7 +4,7 @@
   .hero
     .hero-image
       - if @event.photo.attached?
-        = image_tag url_for(@event.landing_page_photo)
+        = image_tag rails_storage_redirect_path(@event.landing_page_photo)
       - else
         = image_tag 'default_event_image.jpg'
     .mx-2

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -16,3 +16,8 @@ es:
       - Oct
       - Nov
       - Dic
+  helpers:
+    submit:
+      create: 'Crear %{model}'
+      update: 'Actualizar %{model}'
+      submit: 'Entregar %{model}'

--- a/config/locales/models/event/en.yml
+++ b/config/locales/models/event/en.yml
@@ -31,7 +31,6 @@ en:
         edit: "Editing %{title}"
         new: New Event
       show_event_link: See Event
-      errors_msg: There was an error with your event.
       preview_label: Click to see a preview of your event's header
       secret_event_help:
         Secret events don't appear on the home page unless someone has RSVPed - you'll need to send people the event link yourself for them to find it.

--- a/config/locales/models/event/en.yml
+++ b/config/locales/models/event/en.yml
@@ -32,7 +32,7 @@ en:
         new: New Event
       show_event_link: See Event
       errors_msg: There was an error with your event.
-      preview_label: This is a preview of how your event's title will appear.
+      preview_label: Click to see a preview of your event's header
       secret_event_help:
         Secret events don't appear on the home page unless someone has RSVPed - you'll need to send people the event link yourself for them to find it.
         This won't stop people who receive the link from giving it to others without your permission.
@@ -40,8 +40,10 @@ en:
       testing_help:
         Events that require testing for COVID-19 will have a banner informing guests of the testing requirement.
         Be sure to explain how to send you evidence of a negative test in your event description.
-      header_photo_help: Photos are scaled and cropped to full-screen width (1900px by 500px).
-      header_photo_crop_prompt:  Click and drag the header image to change how your header image will be cropped.
+      header_photo_help:
+        Photos are scaled and cropped to full-screen width (1900px by 500px).
+        Open the event preview at the top of the page to adjust how your header image will appear.
+      header_photo_crop_prompt:  Drag the image to change how it will be cropped.
       description_uses_markdown_html: You can format the event description with %{link} to make text bold, add links, or organize things into bullet points.
       description_uses_markdown_name: Markdown
       labels:

--- a/config/locales/models/event/es.yml
+++ b/config/locales/models/event/es.yml
@@ -33,7 +33,6 @@ es:
         edit: "Editando a %{title}"
         new: Evento Nuevo
       show_event_link: Mira a Evento
-      errors_msg: Hubo un errór con su evento.
       preview_label: Haga clic para ver un avance del encabezado de su evento.
       secret_event_help:
         Eventos secretos no aparecen en la página de inicio a menos que el usuario haya respondido - se necesita enviar el enlace a las personas usted mismo para que lo encuentren.

--- a/config/locales/models/event/es.yml
+++ b/config/locales/models/event/es.yml
@@ -34,7 +34,7 @@ es:
         new: Evento Nuevo
       show_event_link: Mira a Evento
       errors_msg: Hubo un errór con su evento.
-      preview_label: Este es un avance de cómo aparecerá el título de su evento.
+      preview_label: Haga clic para ver un avance del encabezado de su evento.
       secret_event_help:
         Eventos secretos no aparecen en la página de inicio a menos que el usuario haya respondido - se necesita enviar el enlace a las personas usted mismo para que lo encuentren.
         Esto no impedirá que las personas a las que usted envíe el enlace se darlo a otras personas sin su permiso.
@@ -42,8 +42,10 @@ es:
       testing_help:
         Eventos que requieren pruebas de COVID-19 tendrá un aviso que informará a los invitados sobre el requisito de la
         prueba. Asegúrese de explicar cómo enviarle evidencia de una prueba negativa en la descripción del evento.
-      header_photo_help: Fotos se escalan y recortan al ancho de pantalla completo (1900px por 500px).
-      header_photo_crop_prompt: Haga clic y arrastre la imagen de encabezado para cambiar cómo se recortará su foto.
+      header_photo_help:
+        Fotos se escalan y recortan al ancho de pantalla completo (1900px por 500px).
+        Abra el avance de evento a la cima de la página para ajustar cómo su imágen de encabezado aparecerá.
+      header_photo_crop_prompt: Arrastre la imagen para cambiar cómo se recortará su foto.
       description_uses_markdown_html: Se puede formatear la descripción del evento con %{link} para poner el texto en negrita, agregar enlaces, o organizar cosas en viñetas.
       description_uses_markdown_name: Markdown
       labels:

--- a/config/locales/models/poll/en.yml
+++ b/config/locales/models/poll/en.yml
@@ -1,4 +1,7 @@
 en:
+  activerecord:
+    models:
+      poll: Poll
   poll:
     created: Poll was successfully created.
     updated: Poll was successfully updated.

--- a/config/locales/models/poll/en.yml
+++ b/config/locales/models/poll/en.yml
@@ -1,7 +1,9 @@
 en:
   activerecord:
     models:
-      poll: Poll
+      poll:
+        one: Poll
+        other: Polls
   poll:
     created: Poll was successfully created.
     updated: Poll was successfully updated.

--- a/config/locales/models/poll/es.yml
+++ b/config/locales/models/poll/es.yml
@@ -1,4 +1,7 @@
 es:
+  activerecord:
+    models:
+      poll: Encuesta
   poll:
     created: Encuesta creado exitosamente.
     updated: Encuesta actualizado exitosamente.

--- a/config/locales/models/poll/es.yml
+++ b/config/locales/models/poll/es.yml
@@ -1,7 +1,9 @@
 es:
   activerecord:
     models:
-      poll: Encuesta
+      poll:
+        one: Encuesta
+        other: Encuestas
   poll:
     created: Encuesta creado exitosamente.
     updated: Encuesta actualizado exitosamente.

--- a/spec/views/events/_form.html.haml_spec.rb
+++ b/spec/views/events/_form.html.haml_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "events/_form" do
     )
 
     expect(rendered).to have_selector('.invalid-feedback')
-    expect(rendered).to have_selector('#error_explanation')
   end
 
   it "asks if the event should be secret" do


### PR DESCRIPTION
Fixes #126.

Stops header photos from being blown away when an invalid event form is submitted.
Updates header preview interface so you don't have to scroll past a huge header photo preview to make your event.